### PR TITLE
updates

### DIFF
--- a/AsyncTwitch/RegisteredPlugins.cs
+++ b/AsyncTwitch/RegisteredPlugins.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,44 +18,84 @@ namespace AsyncTwitch
         public event Action<TwitchConnection, string> _onChannelJoined = null;
         public event Action<TwitchConnection, string> _onChannelParted = null;
 
+        // OnConnected
         public void OnConnected(TwitchConnection obj)
         {
             _onConnected?.Invoke(obj);
         }
+        public Action<TwitchConnection> GetOnConnected()
+        {
+            return _onConnected;
+        }
 
+        // OnRawMessageReceived
         public void OnRawMessageReceived(string stringMsg)
         {
             _onRawMessageReceived?.Invoke(stringMsg);
         }
+        public Action<string> GetOnRawMessageReceived()
+        {
+            return _onRawMessageReceived;
+        }
 
+        // OnRoomStateChanged
         public void OnRoomStateChanged(TwitchConnection obj, RoomState roomstate)
         {
             _onRoomStateChanged?.Invoke(obj, roomstate);
         }
+        public Action<TwitchConnection, RoomState> GetOnRoomStateChanged()
+        {
+            return _onRoomStateChanged;
+        }
 
+        // OnMessageReceived
         public void OnMessageReceived(TwitchConnection obj, TwitchMessage msg)
         {
             _onMessageReceived?.Invoke(obj, msg);
         }
+        public Action<TwitchConnection, TwitchMessage> GetOnMessageReceived()
+        {
+            return _onMessageReceived;
+        }
 
-        public void OnChatJoined(TwitchConnection obj, string msg)
+        // OnChatJoined
+        public void OnChatJoined(TwitchConnection obj)
         {
             _onChatJoined?.Invoke(obj);
         }
+        public Action<TwitchConnection> GetOnChatJoined()
+        {
+            return _onChatJoined;
+        }
 
-        public void OnChatParted(TwitchConnection obj, ChatUserListing user, string msg)
+        // OnChatParted
+        public void OnChatParted(TwitchConnection obj, ChatUserListing user)
         {
             _onChatParted?.Invoke(obj, user.User);
         }
+        public Action<TwitchConnection, ChatUser> GetOnChatParted()
+        {
+            return _onChatParted;
+        }
 
+        // OnChannelJoined
         public void OnChannelJoined(TwitchConnection obj, string channel)
         {
             _onChannelJoined?.Invoke(obj, channel);
         }
+        public Action<TwitchConnection, string> GetOnChannelJoined()
+        {
+            return _onChannelJoined;
+        }
 
+        // OnChannelParted
         public void OnChannelParted(TwitchConnection obj, string channel)
         {
             _onChannelParted?.Invoke(obj, channel);
+        }
+        public Action<TwitchConnection, string> GetOnChannelParted()
+        {
+            return _onChannelParted;
         }
     }
 }


### PR DESCRIPTION
-Implement callbacks as properties
-Implement task queue for starting tasks that can't be directly started (for instance, a task we want to trigger from within a property getter or setter)
-Removed plugin registration from property getters/setters. If the user doesn't call StartConnection first (which registers their plugin), they're doing it wrong anyway.